### PR TITLE
change mentions of <Project Radius> to just <Radius>

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Project Radius Website
+name: Radius Website
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Radius Website
+# Radius
 
-[![Project Radius Website](https://github.com/project-radius/website/actions/workflows/main.yml/badge.svg)](https://github.com/project-radius/website/actions/workflows/main.yml)
+[![Radius Website](https://github.com/project-radius/website/actions/workflows/main.yml/badge.svg)](https://github.com/project-radius/website/actions/workflows/main.yml)
 
-This repository contains the source code for the Project Radius website, available at https://radapp.dev.
+This repository contains the source code for the Radius website, available at https://radapp.dev.
 
 ## Contributing
 

--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,6 +1,6 @@
 ######################## default configuration ####################
 baseURL = "https://radapp.dev/"
-title = "Project Radius"
+title = "Radius"
 theme = "bigspring-light"
 disableFastRender = true
 # post pagination

--- a/config/_default/languages.toml
+++ b/config/_default/languages.toml
@@ -1,7 +1,7 @@
 ############################# English ############################
 [en]
 languageName = "En"
-title = "Project Radius"
+title = "Radius"
 contentDir = "content"
 weight = 1
 ########### footer content ##########
@@ -10,4 +10,4 @@ footer_menu_middle = "Product"
 footer_menu_right = "Support"
 footer_content = "Brought to you by the Azure Incubations team"
 # copyright
-copyright = "© Project Radius Authors"
+copyright = "© Radius Authors"

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -3,8 +3,8 @@ logo = "images/logo.png"
 logo_width = "200px"
 favicon = "favicon.ico"
 # OpenGraph / Twitter Card metadata
-description = "Project Radius is a cloud-native, portable, application platform"
-author = "Project Radius Core Team"
+description = "Radius is a cloud-native, portable, application platform"
+author = "Radius Core Team"
 image = "images/logo.png" # this image will be used as fallback if a page has no image of its own
 # contact form action
 contact_form_action = "#" # contact form works with https://formspree.io

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,7 +12,7 @@ banner:
 ##################### Feature ##########################
 feature:
   enable : false
-  title : "What Project Radius offers application teams"
+  title : "What Radius offers application teams"
   feature_item:
     # feature item loop
     - name : "App-centric Experiences"
@@ -52,7 +52,7 @@ service:
     - title : "Leverage the Radius<br />application graph"
       images:
       - "images/connections.png"
-      content : "Applications are more than just flat lists of resources; they are an interconnected graph of services, databases, gateways, and more. Project Radius allows teams to model, visualize, and automate applications through the new Radius application graph."
+      content : "Applications are more than just flat lists of resources; they are an interconnected graph of services, databases, gateways, and more. Radius allows teams to model, visualize, and automate applications through the new Radius application graph."
       button:
         enable : true
         label : "Learn more"
@@ -62,7 +62,7 @@ service:
     - title : "Build apps that are portable<br />across clouds and on-prem"
       images:
       - "images/platforms.png"
-      content : "Project Radius makes it easy to build and operate applications across cloud (_Azure, AWS, and more_) and on-premises with pluggable infrastructure and consistent tooling. Developers describe their application's requirements (_databases, caching, identity, and more_), and operators bind apps to platforms leveraging Radius environments."
+      content : "Radius makes it easy to build and operate applications across cloud (_Azure, AWS, and more_) and on-premises with pluggable infrastructure and consistent tooling. Developers describe their application's requirements (_databases, caching, identity, and more_), and operators bind apps to platforms leveraging Radius environments."
       button:
         enable : true
         label : "Learn more"
@@ -106,7 +106,7 @@ call_to_action:
   enable : true
   title : "Ready to get started?"
   image : "images/tools.png"
-  content : "Visit the Project Radius getting started guide to learn more and begin rad-ifying your first application today."
+  content : "Visit the Radius getting started guide to learn more and begin rad-ifying your first application today."
   button:
     enable : true
     label : "Get Started"


### PR DESCRIPTION
This change is to replace all mentions of "Project Radius" to just "Radius" as a part of the rebranding effort leading up to public release.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Fixes: [ADO-6722](https://dev.azure.com/azure-octo/Incubations/_workitems/edit/6722)