### PR TITLE
Add google analytics id

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -10,7 +10,7 @@ summaryLength = "15"
 # disqus short name
 disqusShortname = "" # get your shortname form here : https://disqus.com
 # google analytics
-googleAnalytics = "" # example : UA-123-45
+googleAnalytics = "G-0EZZYE4MPR" # example : UA-123-45
 # unsafe html
 [markup.goldmark.renderer]
 unsafe = true


### PR DESCRIPTION
Adding the google analytics id that was created but not added to website config