### PR TITLE
Fix 404 on Infrastructure Recipes "Learn More" link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -76,7 +76,7 @@ service:
       button:
         enable: true
         label: "Learn More"
-        link: "https://docs.radapp.io/guides/recipes/overview"
+        link: "https://docs.radapp.io/guides/recipes/"
 
     # Cloud neutral
     - title: "Cloud Neutral"


### PR DESCRIPTION
## Description

The home page "Infrastructure Recipes → Learn More" link pointed to `https://docs.radapp.io/guides/recipes/overview`, which returns a **404**.

This updates the link in `content/_index.md` to `https://docs.radapp.io/guides/recipes/`, which returns **200**.

## Verification

- `https://docs.radapp.io/guides/recipes/overview` → 404 (broken)
- `https://docs.radapp.io/guides/recipes/` → 200 (working)

Fixes #45