### PR TITLE
Fix broken homepage links and YouTube embed (Error 153)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -56,7 +56,7 @@ service:
       button:
         enable: false
         label: "Learn More"
-        link: "https://docs.radapp.io/concepts/application-graph"
+        link: "https://docs.radapp.io/concepts/applications/"
 
     # Application Graph
     - title: "Application Graph"
@@ -66,7 +66,7 @@ service:
       button:
         enable: false
         label: "Learn More"
-        link: "https://docs.radapp.io/concepts/application-graph"
+        link: "https://docs.radapp.io/concepts/applications/"
       
     #  Environments and Recipes
     - title: "Infrastructure Recipes"

--- a/themes/bigspring-light/layouts/index.html
+++ b/themes/bigspring-light/layouts/index.html
@@ -131,7 +131,7 @@
     </div>
   </div>
   {{ with .image }} <img src="{{ . | relURL }}" alt="" class="img-fluid w-100">{{ end }}
-  {{ $ytSrc := "" }}{{ if .youtube_url }}{{ $ytSrc = .youtube_url }}{{ else if .youtube }}{{ $ytSrc = printf "https://www.youtube.com/embed/%s" .youtube }}{{ end }}{{ with $ytSrc }}<div style="display: flex; justify-content: center; align-items: center;"><iframe width="700" height="400" src="{{ . | safeURL }}" title="YouTube video player" style="border-radius: 15px; overflow: hidden;" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>{{ end }}
+  {{ $ytSrc := "" }}{{ if .youtube_url }}{{ $ytSrc = .youtube_url }}{{ else if .youtube }}{{ $ytSrc = printf "https://www.youtube.com/embed/%s" .youtube }}{{ end }}{{ with $ytSrc }}<div style="display: flex; justify-content: center; align-items: center;"><iframe width="700" height="400" src="{{ . | safeURL }}" title="YouTube video player" style="border-radius: 15px; overflow: hidden;" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>{{ end }}
 </section>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Fixes broken homepage items found while link-testing [https://radapp.io](https://radapp.io) with Playwright.

## 1. Broken `concepts/application-graph` links (`content/_index.md`)

The docs `concepts/` section was restructured and `concepts/application-graph` no longer exists (404). Updated both "Learn More" buttons to [`/concepts/applications/`](https://docs.radapp.io/concepts/applications/), which now documents the application graph (it has a dedicated "The application graph" section). Verified HTTP 200.

| Old URL (404) | New URL (200) |
|---|---|
| `https://docs.radapp.io/concepts/application-graph` | `https://docs.radapp.io/concepts/applications/` |
| `https://docs.radapp.io/concepts/application-graph` | `https://docs.radapp.io/concepts/applications/` |

(These two links are on buttons with `enable: false`, so they aren't rendered on the live site, but the broken URLs were still in source.)

## 2. YouTube embed "Error 153 – Video player configuration error" (`themes/bigspring-light/layouts/index.html`)

The homepage "Learn more about Radius" video failed to load with **Error 153**. Root cause: the site sends `Referrer-Policy: same-origin`, which strips the referrer on cross-origin requests, so the YouTube player can't verify the embedding origin and refuses to play.

Fix: add `referrerpolicy="strict-origin-when-cross-origin"` to the embed iframe (the same value YouTube uses in its own oEmbed embed code), which overrides the document policy for that frame so the player receives the origin.

Reproduced the error and verified the fix loads the video correctly before/after the change.

## Verification

Crawled all 3 pages in the radapp.io sitemap (`/`, `/categories/`, `/tags/`) and validated all 21 unique links — including every outbound `docs.radapp.io` link — all return HTTP 200.

Closes #58