### PR TITLE
Fix missing images on PR preview deployments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
     env:
       GOVER: "^1.17"
       HUGO_ENV: production
-      SWA_BASE: brave-pond-00b49761e
     steps:
       - name: Checkout website repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -41,9 +40,10 @@ jobs:
       - name: Build Hugo Site
         run: |
           if [ "${GITHUB_EVENT_NAME}" == 'pull_request' ]; then
-            STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.3.azurestaticapps.net/"
+            hugo -b "/"
+          else
+            hugo
           fi
-          hugo ${STAGING_URL+-b "$STAGING_URL"}
 
       - name: Upload Hugo artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Problem

Azure Static Web Apps PR-preview deployments render all images blank (0×0). The CI workflow baked a *guessed* preview hostname into Hugo's `baseURL`:

```yaml
STAGING_URL="https://${SWA_BASE}-${{github.event.number}}.3.azurestaticapps.net/"
hugo ${STAGING_URL+-b "$STAGING_URL"}
```

This produced e.g. `https://brave-pond-00b49761e-59.3.azurestaticapps.net/`, which the theme emits as `<base href="{{ site.BaseURL }}">` (`themes/bigspring-light/layouts/partials/head.html`).

But Azure actually serves the preview from a **region-qualified** host like `https://brave-pond-00b49761e-59.westus2.3.azurestaticapps.net/`. Because the `<base href>` host differs from the host actually serving the page, every relative asset URL (e.g. `/images/...`) resolves cross-origin. Chrome blocks those requests with `ERR_BLOCKED_BY_ORB`, so images render blank.

## Fix

For `pull_request` builds, stop guessing the preview hostname and build with a **root-relative** baseURL so `<base href="/">` resolves against whatever host actually serves the page:

```yaml
- name: Build Hugo Site
  run: |
    if [ "${GITHUB_EVENT_NAME}" == 'pull_request' ]; then
      hugo -b "/"
    else
      hugo
    fi
```

The now-unused `SWA_BASE` env var was removed (it was only referenced by the old step).

## Why production is unaffected

Production builds (push to `main`) take the `else` branch and use the repo's configured `baseURL` (`https://radapp.io/`), which already matches its serving domain. Only the preview branch behavior changes.